### PR TITLE
 URL encode oembed params because ruby-oembed isn't.

### DIFF
--- a/app/controllers/blacklight/oembed/embed_controller.rb
+++ b/app/controllers/blacklight/oembed/embed_controller.rb
@@ -9,7 +9,7 @@ module Blacklight::Oembed
 
     def get_embed_content(url, add_params)
       begin
-        OEmbed::Providers.get(url, **add_params).html.html_safe
+        OEmbed::Providers.get(url, **add_params.transform_values { |v| URI.encode(v) }).html.html_safe
       rescue OEmbed::NotFound
         response.status = 400
         ""

--- a/blacklight-oembed.gemspec
+++ b/blacklight-oembed.gemspec
@@ -22,14 +22,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bootstrap-sass", "~> 3.0"
   spec.add_dependency "ruby-oembed"
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails", "~> 3.1"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "rspec-activemodel-mocks"
   spec.add_development_dependency "rspec-collection_matchers"
   spec.add_development_dependency "solr_wrapper"
-  spec.add_development_dependency "engine_cart", "~> 0.8"
+  spec.add_development_dependency "engine_cart", "~> 2.0"
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "poltergeist", ">= 1.5.0"
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -308,7 +308,6 @@
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
@@ -317,7 +316,6 @@
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
        <analyzer>
           <tokenizer class="solr.KeywordTokenizerFactory"/>
-          <filter class="solr.StandardFilterFactory"/>
           <filter class="solr.LowerCaseFilterFactory"/>
           <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
        </analyzer>

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -8,7 +8,7 @@ describe Blacklight::Oembed::EmbedController do
 
     before do
       Blacklight::Oembed::Engine.config.render_helper = :render_oembed_tag_embed
-      Blacklight::Oembed::Engine.config.additional_params = [:canvas_index]
+      Blacklight::Oembed::Engine.config.additional_params = [:canvas_index, :suggested_search]
     end
 
     let :oembed_obj do
@@ -32,6 +32,12 @@ describe Blacklight::Oembed::EmbedController do
     it 'passes along configured additional keys' do
       allow(OEmbed::Providers).to receive(:get).with('http://some/uri', canvas_index: '5').and_return oembed_obj
       get :show, params: { url: 'http://some/uri', canvas_index: '5' }
+      expect(response.status).to eq 200
+    end
+
+    it 'URI encodes data from additional keys' do
+      allow(OEmbed::Providers).to receive(:get).with('http://some/uri', suggested_search: 'ep%C3%A9e').and_return oembed_obj
+      get :show, params: { url: 'http://some/uri', suggested_search: 'epée' }
       expect(response.status).to eq 200
     end
   end


### PR DESCRIPTION
This hopefully fixes https://github.com/sul-dlss/exhibits/issues/1401

Upstream just uses string concatenation to tack on query parameters.. it also hasn't had a commit in a couple years, so.... I guess we just need to do it ourselves.