### PR TITLE
Remove bootstrap dependency

### DIFF
--- a/blacklight-oembed.gemspec
+++ b/blacklight-oembed.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails"
   spec.add_dependency "blacklight", ">= 5.0", "< 7"
-  spec.add_dependency "bootstrap-sass", "~> 3.0"
   spec.add_dependency "ruby-oembed"
 
   spec.add_development_dependency "bundler", ">= 1.5"


### PR DESCRIPTION
I can't seem to find the reason to keep this around. Maybe I'm missing something?